### PR TITLE
Actionpanel

### DIFF
--- a/mapviz/include/mapviz/mapviz.h
+++ b/mapviz/include/mapviz/mapviz.h
@@ -92,13 +92,14 @@ namespace mapviz
     void SelectNewDisplay();
     void RemoveDisplay();
     void RemoveDisplay(QListWidgetItem* item);
-    void ReorderDisplays();
+    void ReorderDisplays(std::string listName);
     void FixedFrameSelected(const QString& text);
     void TargetFrameSelected(const QString& text);
     void UpdateFrames();
     void SpinOnce();
     void UpdateSizeHints();
     void ToggleConfigPanel(bool on);
+    void ToggleActionPanel(bool on);
     void ToggleStatusBar(bool on);
     void ToggleCaptureTools(bool on);
     void ToggleFixOrientation(bool on);
@@ -184,8 +185,11 @@ namespace mapviz
 
     void Open(const std::string& filename);
     void Save(const std::string& filename);
+    void SavePluginList(YAML::Emitter& emitter, const std::string& listName, const std::string& config_path);
+    void UpdateHintSizesByList(const std::string& listName);
 
     MapvizPluginPtr CreateNewDisplay(
+        const std::string& listName,
         const std::string& name,
         const std::string& type,
         bool visible,
@@ -196,6 +200,7 @@ namespace mapviz
       AddMapvizDisplay::Request& req,
       AddMapvizDisplay::Response& resp);
 
+    mapviz::PluginConfigList* GetPluginConfigListByName(const std::string& name);
     void ClearDisplays();
     void AdjustWindowSize();
 

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -172,8 +172,15 @@ Mapviz::Mapviz(bool is_standalone, int argc, char** argv, QWidget *parent, Qt::W
   canvas_ = new MapCanvas(this);
   setCentralWidget(canvas_);
 
+  QSignalMapper* signalMapper = new QSignalMapper (this) ;;
+  connect (ui_.configs, SIGNAL(ItemsMoved()), signalMapper, SLOT(map())) ;
+  connect (ui_.actions, SIGNAL(ItemsMoved()), signalMapper, SLOT(map())) ;
+  signalMapper -> setMapping (ui_.configs, "config") ;
+  signalMapper -> setMapping (ui_.actions, "action") ;
+  connect (signalMapper, SIGNAL(mapped(std::string)), this, SLOT(ReorderDisplays(std::string))) ;
+
   connect(canvas_, SIGNAL(Hover(double,double,double)), this, SLOT(Hover(double,double,double)));
-  connect(ui_.configs, SIGNAL(ItemsMoved()), this, SLOT(ReorderDisplays()));
+  // connect(ui_.configs, SIGNAL(ItemsMoved()), this, SLOT(ReorderDisplays()));
   connect(ui_.actionExit, SIGNAL(triggered()), this, SLOT(close()));
   connect(ui_.actionClear, SIGNAL(triggered()), this, SLOT(ClearConfig()));
   connect(ui_.bg_color, SIGNAL(colorEdited(const QColor &)), this, SLOT(SelectBackgroundColor(const QColor &)));
@@ -604,6 +611,13 @@ void Mapviz::Open(const std::string& filename)
       ui_.actionConfig_Dock->setChecked(show_displays);
     }
 
+    if (swri_yaml_util::FindValue(doc, "show_actions"))
+    {
+      bool show_actions = false;
+      doc["show_actions"] >> show_actions;
+      ui_.actionAction_Dock->setChecked(show_actions);
+    }
+
     if (swri_yaml_util::FindValue(doc, "show_capture_tools"))
     {
       bool show_capture_tools = false;
@@ -704,7 +718,12 @@ void Mapviz::Open(const std::string& filename)
       const YAML::Node& displays = doc["displays"];
       for (uint32_t i = 0; i < displays.size(); i++)
       {
-        std::string type, name;
+        std::string listName, type, name;
+        if (displays[i]["listName"]) {
+          displays[i]["listName"] >> listName;
+        } else {
+          listName = "config";
+        }
         displays[i]["type"] >> type;
         displays[i]["name"] >> name;
 
@@ -719,7 +738,7 @@ void Mapviz::Open(const std::string& filename)
         try
         {
           MapvizPluginPtr plugin =
-              CreateNewDisplay(name, type, visible, collapsed);
+              CreateNewDisplay(listName, name, type, visible, collapsed);
           plugin->LoadConfig(config, config_path);
           plugin->DrawIcon();
         }
@@ -775,6 +794,7 @@ void Mapviz::Save(const std::string& filename)
   out << YAML::Key << "rotate_90" << YAML::Value << ui_.actionRotate_90->isChecked();
   out << YAML::Key << "enable_antialiasing" << YAML::Value << ui_.actionEnable_Antialiasing->isChecked();
   out << YAML::Key << "show_displays" << YAML::Value << ui_.actionConfig_Dock->isChecked();
+  out << YAML::Key << "show_actions" << YAML::Value << ui_.actionAction_Dock->isChecked();
   out << YAML::Key << "show_status_bar" << YAML::Value << ui_.actionShow_Status_Bar->isChecked();
   out << YAML::Key << "show_capture_tools" << YAML::Value << ui_.actionShow_Capture_Tools->isChecked();
   out << YAML::Key << "window_width" << YAML::Value << width();
@@ -799,27 +819,11 @@ void Mapviz::Save(const std::string& filename)
     out << YAML::Key << "force_480p" << YAML::Value << force_480p_;
   }
 
-  if (ui_.configs->count() > 0)
+  if (ui_.configs->count() > 0 || ui_.actions->count() > 0)
   {
     out << YAML::Key << "displays"<< YAML::Value << YAML::BeginSeq;
-
-    for (int i = 0; i < ui_.configs->count(); i++)
-    {
-      out << YAML::BeginMap;
-      out << YAML::Key << "type" << YAML::Value << plugins_[ui_.configs->item(i)]->Type();
-      out << YAML::Key << "name" << YAML::Value << (static_cast<ConfigItem*>(ui_.configs->itemWidget(ui_.configs->item(i))))->Name().toStdString();
-      out << YAML::Key << "config" << YAML::Value;
-      out << YAML::BeginMap;
-
-      out << YAML::Key << "visible" << YAML::Value << plugins_[ui_.configs->item(i)]->Visible();
-      out << YAML::Key << "collapsed" << YAML::Value << (static_cast<ConfigItem*>(ui_.configs->itemWidget(ui_.configs->item(i))))->Collapsed();
-
-      plugins_[ui_.configs->item(i)]->SaveConfig(out, config_path);
-
-      out << YAML::EndMap;
-      out << YAML::EndMap;
-    }
-
+    SavePluginList(out, "config", config_path);
+    SavePluginList(out, "action", config_path);
     out << YAML::EndSeq;
   }
 
@@ -827,6 +831,32 @@ void Mapviz::Save(const std::string& filename)
 
   fout << out.c_str();
   fout.close();
+}
+
+void Mapviz::SavePluginList(YAML::Emitter& emitter, const std::string& listName, const std::string& config_path)
+{
+  mapviz::PluginConfigList* list = GetPluginConfigListByName(listName);
+  if (list->count() <= 0)
+  {
+    return;
+  }
+  for (int i = 0; i < list->count(); i++)
+  {
+    emitter << YAML::BeginMap;
+    emitter << YAML::Key << "listName" << YAML::Value << listName;
+    emitter << YAML::Key << "type" << YAML::Value << plugins_[list->item(i)]->Type();
+    emitter << YAML::Key << "name" << YAML::Value << (static_cast<ConfigItem*>(list->itemWidget(list->item(i))))->Name().toStdString();
+    emitter << YAML::Key << "config" << YAML::Value;
+    emitter << YAML::BeginMap;
+
+    emitter << YAML::Key << "visible" << YAML::Value << plugins_[list->item(i)]->Visible();
+    emitter << YAML::Key << "collapsed" << YAML::Value << (static_cast<ConfigItem*>(list->itemWidget(list->item(i))))->Collapsed();
+
+    plugins_[list->item(i)]->SaveConfig(emitter, config_path);
+
+    emitter << YAML::EndMap;
+    emitter << YAML::EndMap;
+  }
 }
 
 void Mapviz::AutoSave()
@@ -945,6 +975,14 @@ void Mapviz::SelectNewDisplay()
   Ui::pluginselect ui;
   ui.setupUi(&dialog);
 
+  QPushButton* obj = qobject_cast<QPushButton * >( sender() );
+  QString senderName = obj -> objectName();
+  std::string listName;
+  if (senderName == "actionaddbutton")
+    listName = "action";
+  else
+    listName = "config";
+
   std::vector<std::string> plugins = loader_->getDeclaredClasses();
   std::map<std::string, std::string> plugin_types;
   for (size_t i = 0; i < plugins.size(); i++)
@@ -965,7 +1003,7 @@ void Mapviz::SelectNewDisplay()
     std::string name = "new display";
     try
     {
-      CreateNewDisplay(name, type, true, false);
+      CreateNewDisplay(listName, name, type, true, false);
     }
     catch (const pluginlib::LibraryLoadException& e)
     {
@@ -1006,20 +1044,19 @@ bool Mapviz::AddDisplay(
     {
       plugin->LoadConfig(config, "");
       plugin->SetVisible(req.visible);
+      mapviz::PluginConfigList* list = GetPluginConfigListByName(req.listName);
 
       if (req.draw_order > 0)
       {
         display.first->setData(Qt::UserRole, QVariant(req.draw_order - 1.1));
-        ui_.configs->sortItems();
-
-        ReorderDisplays();
+        list->sortItems();
+        ReorderDisplays(req.listName);
       }
       else if (req.draw_order < 0)
       {
-        display.first->setData(Qt::UserRole, QVariant(ui_.configs->count() + req.draw_order + 0.1));
-        ui_.configs->sortItems();
-
-        ReorderDisplays();
+        display.first->setData(Qt::UserRole, QVariant(list->count() + req.draw_order + 0.1));
+        list->sortItems();
+        ReorderDisplays(req.listName);
       }
 
       resp.success = true;
@@ -1031,7 +1068,7 @@ bool Mapviz::AddDisplay(
   try
   {
     MapvizPluginPtr plugin =
-      CreateNewDisplay(req.name, req.type, req.visible, false, req.draw_order);
+      CreateNewDisplay(req.listName, req.name, req.type, req.visible, false, req.draw_order);
     plugin->LoadConfig(config, "");
     plugin->DrawIcon();
     resp.success = true;
@@ -1126,12 +1163,14 @@ void Mapviz::Hover(double x, double y, double scale)
 }
 
 MapvizPluginPtr Mapviz::CreateNewDisplay(
+    const std::string& listName,
     const std::string& name,
     const std::string& type,
     bool visible,
     bool collapsed,
     int draw_order)
 {
+  mapviz::PluginConfigList* list = GetPluginConfigListByName(listName);
   ConfigItem* config_item = new ConfigItem();
 
   config_item->SetName(name.c_str());
@@ -1146,7 +1185,7 @@ MapvizPluginPtr Mapviz::CreateNewDisplay(
   }
 
 
-  ROS_INFO("creating: %s", real_type.c_str());
+  ROS_INFO("creating: %s, in panel: ", real_type.c_str(), listName.c_str());
   MapvizPluginPtr plugin = loader_->createInstance(real_type.c_str());
 
   // Setup configure widget
@@ -1160,15 +1199,15 @@ MapvizPluginPtr Mapviz::CreateNewDisplay(
 
   if (draw_order == 0)
   {
-    plugin->SetDrawOrder(ui_.configs->count());
+    plugin->SetDrawOrder(list->count());
   }
   else if (draw_order > 0)
   {
-    plugin->SetDrawOrder(std::min(ui_.configs->count(), draw_order - 1));
+    plugin->SetDrawOrder(std::min(list->count(), draw_order - 1));
   }
   else if (draw_order < 0)
   {
-    plugin->SetDrawOrder(std::max(0, ui_.configs->count() + draw_order + 1));
+    plugin->SetDrawOrder(std::max(0, list->count() + draw_order + 1));
   }
 
   QString pretty_type(real_type.c_str());
@@ -1195,15 +1234,15 @@ MapvizPluginPtr Mapviz::CreateNewDisplay(
 
   if (draw_order == 0)
   {
-    ui_.configs->addItem(item);
+    list->addItem(item);
   }
   else
   {
-    ui_.configs->insertItem(plugin->DrawOrder(), item);
+    list->insertItem(plugin->DrawOrder(), item);
   }
 
-  ui_.configs->setItemWidget(item, config_item);
-  ui_.configs->UpdateIndices();
+  list->setItemWidget(item, config_item);
+  list->UpdateIndices();
 
   // Add plugin to canvas
   plugin->SetTargetFrame(ui_.fixedframe->currentText().toStdString());
@@ -1215,9 +1254,17 @@ MapvizPluginPtr Mapviz::CreateNewDisplay(
   if (collapsed)
     config_item->Hide();
 
-  ReorderDisplays();
+  ReorderDisplays(listName);
 
   return plugin;
+}
+
+mapviz::PluginConfigList* Mapviz::GetPluginConfigListByName(const std::string& name)
+{
+  if (name == "action")
+    return ui_.actions;
+  else
+    return ui_.configs;
 }
 
 void Mapviz::ToggleShowPlugin(QListWidgetItem* item, bool visible)
@@ -1280,6 +1327,20 @@ void Mapviz::ToggleConfigPanel(bool on)
   else
   {
     ui_.configdock->hide();
+  }
+
+  AdjustWindowSize();
+}
+
+void Mapviz::ToggleActionPanel(bool on)
+{
+  if (on)
+  {
+    ui_.actiondock->show();
+  }
+  else
+  {
+    ui_.actiondock->hide();
   }
 
   AdjustWindowSize();
@@ -1452,10 +1513,17 @@ void Mapviz::Screenshot()
 
 void Mapviz::UpdateSizeHints()
 {
-  for (int i = 0; i < ui_.configs->count(); i++)
+  UpdateHintSizesByList("action");
+  UpdateHintSizesByList("config");
+}
+
+void Mapviz::UpdateHintSizesByList(const std::string& listName)
+{
+  mapviz::PluginConfigList* list = GetPluginConfigListByName(listName);
+  for (int i = 0; i < list->count(); i++)
   {
-    QListWidgetItem* item = ui_.configs->item(i);
-    ConfigItem* widget = static_cast<ConfigItem*>(ui_.configs->itemWidget(item));
+    QListWidgetItem* item = list->item(i);
+    ConfigItem* widget = static_cast<ConfigItem*>(list->itemWidget(item));
     if (widget) {
       // Make sure the ConfigItem in the QListWidgetItem we're getting really
       // exists; if this method is called before it's been initialized, it would
@@ -1467,8 +1535,16 @@ void Mapviz::UpdateSizeHints()
 
 void Mapviz::RemoveDisplay()
 {
-  QListWidgetItem* item = ui_.configs->takeItem(ui_.configs->currentRow());
-  RemoveDisplay(item);
+  QPushButton* obj = qobject_cast<QPushButton * >( sender() );
+  QString senderName = obj -> objectName();
+  if (senderName == "actionremovebutton")
+  {
+    RemoveDisplay(ui_.actions->takeItem(ui_.actions->currentRow()));
+  }
+  else
+  {
+    RemoveDisplay(ui_.configs->takeItem(ui_.configs->currentRow()));
+  }
 }
 
 void Mapviz::RemoveDisplay(QListWidgetItem* item)
@@ -1497,14 +1573,27 @@ void Mapviz::ClearDisplays()
 
     delete item;
   }
+  while (ui_.actions->count() > 0)
+  {
+    ROS_INFO("Remove display ...");
+
+    QListWidgetItem* item = ui_.actions->takeItem(0);
+
+    canvas_->RemovePlugin(plugins_[item]);
+    plugins_.erase(item);
+
+    delete item;
+  }
 }
 
-void Mapviz::ReorderDisplays()
+void Mapviz::ReorderDisplays(std::string listName)
 {
+  mapviz::PluginConfigList* list = GetPluginConfigListByName(listName);
+
   ROS_INFO("Reorder displays");
-  for (int i = 0; i < ui_.configs->count(); i++)
+  for (int i = 0; i < list->count(); i++)
   {
-    plugins_[ui_.configs->item(i)]->SetDrawOrder(i);
+    plugins_[list->item(i)]->SetDrawOrder(i);
   }
   canvas_->ReorderDisplays();
 }

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -172,15 +172,7 @@ Mapviz::Mapviz(bool is_standalone, int argc, char** argv, QWidget *parent, Qt::W
   canvas_ = new MapCanvas(this);
   setCentralWidget(canvas_);
 
-  QSignalMapper* signalMapper = new QSignalMapper (this) ;;
-  connect (ui_.configs, SIGNAL(ItemsMoved()), signalMapper, SLOT(map())) ;
-  connect (ui_.actions, SIGNAL(ItemsMoved()), signalMapper, SLOT(map())) ;
-  signalMapper -> setMapping (ui_.configs, "config") ;
-  signalMapper -> setMapping (ui_.actions, "action") ;
-  connect (signalMapper, SIGNAL(mapped(std::string)), this, SLOT(ReorderDisplays(std::string))) ;
-
   connect(canvas_, SIGNAL(Hover(double,double,double)), this, SLOT(Hover(double,double,double)));
-  // connect(ui_.configs, SIGNAL(ItemsMoved()), this, SLOT(ReorderDisplays()));
   connect(ui_.actionExit, SIGNAL(triggered()), this, SLOT(close()));
   connect(ui_.actionClear, SIGNAL(triggered()), this, SLOT(ClearConfig()));
   connect(ui_.bg_color, SIGNAL(colorEdited(const QColor &)), this, SLOT(SelectBackgroundColor(const QColor &)));
@@ -190,6 +182,13 @@ Mapviz::Mapviz(bool is_standalone, int argc, char** argv, QWidget *parent, Qt::W
   connect(stop_button_, SIGNAL(clicked()), this, SLOT(StopRecord()));
   connect(screenshot_button_, SIGNAL(clicked()), this, SLOT(Screenshot()));
   connect(ui_.actionClear_History, SIGNAL(triggered()), this, SLOT(ClearHistory()));
+  
+  QSignalMapper* pclMapper = new QSignalMapper (this) ;;
+  connect (ui_.configs, SIGNAL(ItemsMoved()), pclMapper, SLOT(map())) ;
+  connect (ui_.actions, SIGNAL(ItemsMoved()), pclMapper, SLOT(map())) ;
+  pclMapper -> setMapping (ui_.configs, "config") ;
+  pclMapper -> setMapping (ui_.actions, "action") ;
+  connect (pclMapper, SIGNAL(mapped(std::string)), this, SLOT(ReorderDisplays(std::string))) ;
 
   // Use a separate thread for writing video files so that it won't cause
   // lag on the main thread.

--- a/mapviz/src/mapviz.cpp
+++ b/mapviz/src/mapviz.cpp
@@ -1184,7 +1184,7 @@ MapvizPluginPtr Mapviz::CreateNewDisplay(
   }
 
 
-  ROS_INFO("creating: %s, in panel: ", real_type.c_str(), listName.c_str());
+  ROS_INFO("creating: %s, in panel: %s.", real_type.c_str(), listName.c_str());
   MapvizPluginPtr plugin = loader_->createInstance(real_type.c_str());
 
   // Setup configure widget

--- a/mapviz/src/mapviz.ui
+++ b/mapviz/src/mapviz.ui
@@ -60,6 +60,7 @@
     <addaction name="actionResizable"/>
     <addaction name="separator"/>
     <addaction name="actionConfig_Dock"/>
+    <addaction name="actionAction_Dock"/>
     <addaction name="actionShow_Status_Bar"/>
     <addaction name="actionShow_Capture_Tools"/>
     <addaction name="separator"/>
@@ -79,6 +80,108 @@
     <bool>true</bool>
    </property>
   </widget>
+  <widget class="QDockWidget" name="actiondock">
+    <property name="minimumSize">
+     <size>
+      <width>332</width>
+      <height>301</height>
+     </size>
+    </property>
+    <property name="features">
+     <set>QDockWidget::DockWidgetMovable</set>
+    </property>
+    <property name="allowedAreas">
+     <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea</set>
+    </property>
+    <property name="windowTitle">
+     <string>Action</string>
+    </property>
+    <attribute name="dockWidgetArea">
+     <number>2</number>
+    </attribute>
+    <widget class="QWidget" name="actionDockWidgetContents">
+     <layout class="QVBoxLayout" name="actionVerticalLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>2</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="mapviz::PluginConfigList" name="actions">
+        <property name="horizontalScrollBarPolicy">
+         <enum>Qt::ScrollBarAsNeeded</enum>
+        </property>
+        <property name="dragEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="dragDropMode">
+         <enum>QAbstractItemView::InternalMove</enum>
+        </property>
+        <property name="defaultDropAction">
+         <enum>Qt::MoveAction</enum>
+        </property>
+        <property name="verticalScrollMode">
+         <enum>QAbstractItemView::ScrollPerPixel</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="actionWidget" native="true">
+        <layout class="QHBoxLayout" name="actionHorizontalLayoutAction">
+         <property name="topMargin">
+          <number>4</number>
+         </property>
+         <property name="bottomMargin">
+          <number>4</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="actionaddbutton">
+           <property name="maximumSize">
+            <size>
+             <width>80</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Add a new display</string>
+           </property>
+           <property name="text">
+            <string>Add</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="actionremovebutton">
+           <property name="maximumSize">
+            <size>
+             <width>80</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Remove the selected display</string>
+           </property>
+           <property name="text">
+            <string>Remove</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </widget>
   <widget class="QDockWidget" name="configdock">
    <property name="minimumSize">
     <size>
@@ -286,7 +389,7 @@
          <number>4</number>
         </property>
         <item>
-         <widget class="QPushButton" name="addbutton">
+         <widget class="QPushButton" name="configaddbutton">
           <property name="maximumSize">
            <size>
             <width>80</width>
@@ -302,7 +405,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="removebutton">
+         <widget class="QPushButton" name="configremovebutton">
           <property name="maximumSize">
            <size>
             <width>80</width>
@@ -352,6 +455,20 @@
     <string>Show the display configuration panel</string>
    </property>
   </action>
+  <action name="actionAction_Dock">
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+    <property name="checked">
+     <bool>true</bool>
+    </property>
+    <property name="text">
+     <string>Show Action Panel</string>
+    </property>
+    <property name="statusTip">
+     <string>Show the action widget panel</string>
+    </property>
+   </action>
   <action name="actionFix_Orientation">
    <property name="checkable">
     <bool>true</bool>
@@ -498,15 +615,49 @@
   <tabstop>targetframe</tabstop>
   <tabstop>bg_color</tabstop>
   <tabstop>configs</tabstop>
-  <tabstop>addbutton</tabstop>
-  <tabstop>removebutton</tabstop>
+  <tabstop>configaddbutton</tabstop>
+  <tabstop>configremovebutton</tabstop>
+  <tabstop>actionaddbutton</tabstop>
+  <tabstop>actionremovebutton</tabstop>
  </tabstops>
  <resources>
   <include location="resources/icons.qrc"/>
  </resources>
  <connections>
   <connection>
-   <sender>addbutton</sender>
+    <sender>actionaddbutton</sender>
+    <signal>clicked()</signal>
+    <receiver>mapviz</receiver>
+    <slot>SelectNewDisplay()</slot>
+    <hints>
+    <hint type="sourcelabel">
+    <x>107</x>
+    <y>573</y>
+    </hint>
+    <hint type="destinationlabel">
+    <x>327</x>
+    <y>471</y>
+    </hint>
+    </hints>
+  </connection>
+  <connection>
+    <sender>actionremovebutton</sender>
+    <signal>clicked()</signal>
+    <receiver>mapviz</receiver>
+    <slot>RemoveDisplay()</slot>
+    <hints>
+     <hint type="sourcelabel">
+      <x>224</x>
+      <y>573</y>
+     </hint>
+     <hint type="destinationlabel">
+      <x>328</x>
+      <y>407</y>
+     </hint>
+    </hints>
+   </connection>
+  <connection>
+   <sender>configaddbutton</sender>
    <signal>clicked()</signal>
    <receiver>mapviz</receiver>
    <slot>SelectNewDisplay()</slot>
@@ -522,7 +673,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>removebutton</sender>
+   <sender>configremovebutton</sender>
    <signal>clicked()</signal>
    <receiver>mapviz</receiver>
    <slot>RemoveDisplay()</slot>
@@ -542,6 +693,22 @@
    <signal>toggled(bool)</signal>
    <receiver>mapviz</receiver>
    <slot>ToggleConfigPanel(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>399</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionAction_Dock</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mapviz</receiver>
+   <slot>ToggleActionPanel(bool)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>-1</x>

--- a/mapviz/srv/AddMapvizDisplay.srv
+++ b/mapviz/srv/AddMapvizDisplay.srv
@@ -1,5 +1,7 @@
 # Add or updates a mapviz display.
 
+string                        listName     # The name of the plugin panel:
+                                           # "config" or "action".
 string                        name         # The name of the display.
 string                        type         # The plugin type.
 


### PR DESCRIPTION
## Overview
Added an action panel which allow plugins to be displayed in an additional panel.

## What I did not like before
The default UI hosts only one plugin panel. It can easily get very cluttered when a few plugins are added. It is difficult to navigate the list and locate the correct plugin to play with, especially on a mobile laptop with a small screen and a track pad. Frequently, misclicking could mess up the plugin list.

![Screenshot from 2023-11-10 17-51-15](https://github.com/ICE9-Robotics/mapviz/assets/8778250/23e0f58b-8ca6-4230-b645-dc1dd5d76a81)

## Solution
My solution is to add a second panel called Action panel. In this panel, I can add the plugins such as move_base, draw_polygon etc. which I frequently use during field work. Then I will hide the Config panel, so the the fancy display components I configured earlier stay intact.

![Screenshot from 2023-11-10 17-54-31](https://github.com/ICE9-Robotics/mapviz/assets/8778250/f5073931-7128-4155-8256-670844b5008c)

## Additional Info
#### Visibility
Both panels can be toggled on and off through menu separately.
#### Config saving and loading
I have made sure save and open config functions behave correctly for both panels.

An additional property, `listName`, is added to each item under the display category to indicate their designated panel:

```
displays:
  - listName: config
    type: mapviz_plugins/laserscan
    name: new display
    config: ....
  - listName: action
    type: mapviz_plugins/attitude_indicator
    name: new display
    config: ....
```
Backward compatibility for old config files [@line 720](https://github.com/ICE9-Robotics/mapviz/blob/d3f23b07b0c48399fe12795b0214bbc4e09cffde/mapviz/src/mapviz.cpp#L720):
```
        std::string listName, type, name;
        if (displays[i]["listName"]) {
          displays[i]["listName"] >> listName;
        } else {
          listName = "config";
        }
        displays[i]["type"] >> type;
        displays[i]["name"] >> name;
```

#### Default panel location
The Config panel defaults to the left docking area, so the Action panel defaults to the right docking area.